### PR TITLE
Correct bullseye dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ def VARIANTS=[
                 ['libgcc1'],
                 ['libstdc++6'],
                 ['libwxbase3.0-0v5'],
-                ['libwxgtk3.0-0v5'],
+                ['libwxgtk3.0-gtk3-0v5'],
                 ['wx3.0-i18n']
         ]],
 	


### PR DESCRIPTION
Hi @wellenvogel ,

this PR corrects following error on Debian/Raspbian Bullseye
" avnav-ocharts-plugin : Depends: libwxgtk3.0-0v5 but it is not installable"

Regards
free-x