### PR TITLE
add raspbian bullseye/arm64 build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,7 @@ def VARIANTS=[
                 ['libwxgtk3.0-gtk3-0v5'],
                 ['wx3.0-i18n']
         ]],
-	[osline:'raspbian',
+        [osline:'raspbian',
          osversion:'bullseye',
          arch: 'arm64',
          dockerbase:'arm64v8/debian',

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ def VARIANTS=[
                  ['libwxbase3.0-0v5'],
                  ['libwxgtk3.0-0v5'],
                  ['wx3.0-i18n']
-         ]],
+        ]],
         [osline:'debian',
          osversion:'buster',
          arch: 'amd64',
@@ -81,7 +81,7 @@ def VARIANTS=[
                  ['libwxbase3.0-0v5'],
                  ['libwxgtk3.0-0v5'],
                  ['wx3.0-i18n']
-         ]],
+        ]],
         [osline:'raspbian',
          osversion:'buster',
          arch: 'armhf', 
@@ -121,7 +121,20 @@ def VARIANTS=[
                 ['libwxgtk3.0-gtk3-0v5'],
                 ['wx3.0-i18n']
         ]],
-	
+	[osline:'raspbian',
+         osversion:'bullseye',
+         arch: 'arm64',
+         dockerbase:'arm64v8/debian',
+         dockerfile:'Dockerfile.gtk3',
+         dependencies:[
+                ['libc6'],
+                ['libgcc1'],
+                ['libstdc++6'],
+                ['libwxbase3.0-0v5'],
+                ['libwxgtk3.0-gtk3-0v5'],
+                ['wx3.0-i18n']
+        ]],
+
 ]
 
 


### PR DESCRIPTION
Hi @wellenvogel,

I am missing arm64 package for Debian/Bullseye. I have added appropriate definition in build.gradle.

Regards
free-x